### PR TITLE
Change copyToClipboard to pyperclip instead of os

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,12 @@
 
 from wox import Wox
 from SavedItems import SavedItems
-import pyperclip
+try:
+    import pyperclip
+except ImportError:
+    import pip
+    pip.main(['install', '--user', 'pyperclip'])
+    import pyperclip
 
 class Recall(Wox):
 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 
 from wox import Wox
 from SavedItems import SavedItems
-import os
+import pyperclip
 
 class Recall(Wox):
 
@@ -75,7 +75,7 @@ class Recall(Wox):
             })
 
     def copyToClipboard(self, value):
-        os.system('echo | set /p nul=' + value.strip() + '| clip')
+        pyperclip.copy(value.strip())
     
     def addResultWrapper(self, results, query_list):
         query_list_length = len(query_list)


### PR DESCRIPTION
I love your Recall Plugin but there is one thing absolutely bugging me, the Copy function opening a Terminal for a short time.

My branch uses pyperclip (needs to be installed) instead of os
→ pyperclip doesn't open the terminal when copying to clipboard → seems, in my opinion, less "scary" that way

Automatic install of pyperclip if it isn't found by pip